### PR TITLE
Renaming 'AcceptanceTest' to 'TestBuildAcceptance'

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -87,7 +87,7 @@ if (-not $Tasks) {
     CopyModule,
     IntegrationTest,
     Deploy,
-    AcceptanceTest
+    TestBuildAcceptance
 
     task Download_All_Dependencies -if ($DownloadDscResources -or $Tasks -contains 'Download_All_Dependencies') DownloadDscResources -Before SetPsModulePath
 }

--- a/Build/Tasks/TestBuildAcceptance.ps1
+++ b/Build/Tasks/TestBuildAcceptance.ps1
@@ -1,4 +1,4 @@
-Task AcceptanceTest {
+Task TestBuildAcceptance {
 
     "`n`tSTATUS: Testing with PowerShell $PSVersion"
 


### PR DESCRIPTION
Minor change to match the naming convention in the DscWorkshop