### PR TITLE
Save & restore PSModulePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,4 @@ set to true when the LCM is already in ApplyAndAutoCorrect mode.
   due to an encoding issue with the psd1 file
 - Add missing documentation
 - Added Read-Only Domaincontroller Variable to AddsDomainController
+- Save & Restore PSModulePath on each DSC resource to reset changes during MOF compilation

--- a/source/DSCResources/AddsDomain/AddsDomain.schema.psm1
+++ b/source/DSCResources/AddsDomain/AddsDomain.schema.psm1
@@ -49,6 +49,8 @@ configuration AddsDomain
         $EnablePrivilegedAccessManagement = $false
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -160,4 +162,7 @@ configuration AddsDomain
             DependsOn        = "[WaitForAdDomain]$($trust.Name)"
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsDomainController/AddsDomainController.schema.psm1
+++ b/source/DSCResources/AddsDomainController/AddsDomainController.schema.psm1
@@ -43,6 +43,8 @@ configuration AddsDomainController
         $InstallationMediaPath
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -75,4 +77,7 @@ configuration AddsDomainController
         IsGlobalCatalog               = $IsGlobalCatalog
         DependsOn                     = '[WaitForADDomain]WaitForestAvailability'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsDomainPrincipals/AddsDomainPrincipals.schema.psm1
+++ b/source/DSCResources/AddsDomainPrincipals/AddsDomainPrincipals.schema.psm1
@@ -23,6 +23,8 @@ configuration AddsDomainPrincipals
         $ManagedServiceAccounts
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -199,4 +201,7 @@ configuration AddsDomainPrincipals
             AddMemberOf -ExecutionName $executionName -ExecutionType ADManagedServiceAccount -AccountName "$($svcAccount.ServiceAccountName)$" -MemberOf $memberOf
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsOrgUnitsAndGroups/AddsOrgUnitsAndGroups.schema.psm1
+++ b/source/DSCResources/AddsOrgUnitsAndGroups/AddsOrgUnitsAndGroups.schema.psm1
@@ -15,6 +15,8 @@ configuration AddsOrgUnitsAndGroups
         $Groups
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -113,4 +115,7 @@ configuration AddsOrgUnitsAndGroups
 
         (Get-DscSplattedResource -ResourceName ADGroup -ExecutionName $group.GroupName -Properties $group -NoInvoke).Invoke($group)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsProtectFromAccidentalDeletion/AddsProtectFromAccidentalDeletion.schema.psm1
+++ b/source/DSCResources/AddsProtectFromAccidentalDeletion/AddsProtectFromAccidentalDeletion.schema.psm1
@@ -57,6 +57,8 @@ configuration AddsProtectFromAccidentalDeletion
         $FilterReplicationSite = '*'
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     if ( $ProtectDomain -eq $true )
@@ -231,4 +233,7 @@ configuration AddsProtectFromAccidentalDeletion
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsServicePrincipalNames/AddsServicePrincipalNames.schema.psm1
+++ b/source/DSCResources/AddsServicePrincipalNames/AddsServicePrincipalNames.schema.psm1
@@ -7,6 +7,8 @@ configuration AddsServicePrincipalNames
         $ServicePrincipalNames
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -15,4 +17,7 @@ configuration AddsServicePrincipalNames
     {
         (Get-DscSplattedResource -ResourceName ADServicePrincipalName -ExecutionName "spn-$((New-Guid).Guid)" -Properties $spn -NoInvoke).Invoke($spn)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsSiteLinks/AddsSiteLinks.schema.psm1
+++ b/source/DSCResources/AddsSiteLinks/AddsSiteLinks.schema.psm1
@@ -7,6 +7,8 @@ configuration AddsSiteLinks
         $SiteLinks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -21,4 +23,6 @@ configuration AddsSiteLinks
         (Get-DscSplattedResource -ResourceName ADReplicationSiteLink -ExecutionName $executionName -Properties $siteLink -NoInvoke).Invoke($siteLink)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsSitesSubnets/AddsSitesSubnets.schema.psm1
+++ b/source/DSCResources/AddsSitesSubnets/AddsSitesSubnets.schema.psm1
@@ -11,6 +11,8 @@ configuration AddsSitesSubnets
         $Subnets
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -30,4 +32,7 @@ configuration AddsSitesSubnets
 
         (Get-DscSplattedResource -ResourceName ADReplicationSubnet -ExecutionName $subnet.Name -Properties $subnet -NoInvoke).Invoke($subnet)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsTrusts/AddsTrusts.schema.psm1
+++ b/source/DSCResources/AddsTrusts/AddsTrusts.schema.psm1
@@ -7,6 +7,8 @@ configuration AddsTrusts
         $Trusts
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -29,4 +31,7 @@ configuration AddsTrusts
         $executionName = "$($trust.SourceDomainName)-to-$($trust.TargetDomainName)".Replace('.','-')
         (Get-DscSplattedResource -ResourceName ADDomainTrust -ExecutionName $executionName -Properties $trust -NoInvoke).Invoke($trust)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AddsWaitForDomains/AddsWaitForDomains.schema.psm1
+++ b/source/DSCResources/AddsWaitForDomains/AddsWaitForDomains.schema.psm1
@@ -7,6 +7,8 @@ configuration AddsWaitForDomains
         $Domains
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ActiveDirectoryDsc
 
@@ -15,4 +17,7 @@ configuration AddsWaitForDomains
         $executionName = $domain.DomainName
         (Get-DscSplattedResource -ResourceName WaitForADDomain -ExecutionName $executionName -Properties $domain -NoInvoke).Invoke($domain)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/AuditPolicies/AuditPolicies.schema.psm1
+++ b/source/DSCResources/AuditPolicies/AuditPolicies.schema.psm1
@@ -20,6 +20,8 @@ configuration AuditPolicies
         $CsvPath
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName AuditPolicyDsc
 
@@ -58,4 +60,7 @@ configuration AuditPolicies
         }
         (Get-DscSplattedResource -ResourceName AuditPolicyCsv -ExecutionName "auditPolicyCsv" -Properties $auditPolicyCsv -NoInvoke).Invoke( $auditPolicyCsv )
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Bitlocker/Bitlocker.schema.psm1
+++ b/source/DSCResources/Bitlocker/Bitlocker.schema.psm1
@@ -15,6 +15,8 @@ configuration Bitlocker
         $AutoDisks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xBitlocker
 
@@ -81,4 +83,7 @@ configuration Bitlocker
             (Get-DscSplattedResource -ResourceName xBLAutoBitlocker -ExecutionName $executionName -Properties $autoDisk -NoInvoke).Invoke($autoDisk)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/CertificateAuthorities/CertificateAuthorities.schema.psm1
+++ b/source/DSCResources/CertificateAuthorities/CertificateAuthorities.schema.psm1
@@ -99,6 +99,8 @@ configuration CertificateAuthorities {
         $ValidityPeriodUnits
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module ActiveDirectoryCSDsc
 
@@ -124,4 +126,7 @@ configuration CertificateAuthorities {
     $executionName = 'CaDeployment'
     (Get-DscSplattedResource -ResourceName AdcsCertificationAuthority -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
 
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/CertificateExports/CertificateExports.schema.psm1
+++ b/source/DSCResources/CertificateExports/CertificateExports.schema.psm1
@@ -6,6 +6,8 @@ configuration CertificateExports {
         $Certificates
     )
     
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module CertificateDsc
 
@@ -14,4 +16,7 @@ configuration CertificateExports {
         $executionName = "certexport_$($cert.Path)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName CertificateExport -ExecutionName $executionName -Properties $cert -NoInvoke).Invoke($cert)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/CertificateImports/CertificateImports.schema.psm1
+++ b/source/DSCResources/CertificateImports/CertificateImports.schema.psm1
@@ -11,6 +11,8 @@ configuration CertificateImports
         $PfxFiles
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module CertificateDsc
 
@@ -29,7 +31,7 @@ configuration CertificateImports
             {
                 if (-not (Test-Path -Path $certFile.Path))
                 {
-                    Write-Error "Certificate file '$($certFile.Path)' not found. Current working directory is: $(Get-Location)"
+                    throw "ERROR: Certificate file '$($certFile.Path)' not found. Current working directory is: $(Get-Location)"
                 }
                 else
                 {
@@ -64,4 +66,7 @@ configuration CertificateImports
             (Get-DscSplattedResource -ResourceName PfxImport -ExecutionName $executionName -Properties $pfxFile -NoInvoke).Invoke($pfxFile)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/CertificateRequests/CertificateRequests.schema.psm1
+++ b/source/DSCResources/CertificateRequests/CertificateRequests.schema.psm1
@@ -31,6 +31,8 @@ configuration CertificateRequests
         [UseMachineContext = [bool]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module CertificateDsc
 
@@ -54,4 +56,7 @@ configuration CertificateRequests
         $executionName = "req_$($request.Subject)" -replace '[\s(){}/\\:=\.-]', '_'
         (Get-DscSplattedResource -ResourceName CertReq -ExecutionName $executionName -Properties $request -NoInvoke).Invoke($request)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ChocolateyPackages/ChocolateyPackages.schema.psm1
+++ b/source/DSCResources/ChocolateyPackages/ChocolateyPackages.schema.psm1
@@ -20,6 +20,8 @@ configuration ChocolateyPackages {
         [hashtable[]]$Packages
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
     Import-DscResource -ModuleName Chocolatey
@@ -363,4 +365,7 @@ configuration ChocolateyPackages {
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ChocolateyPackages2nd/ChocolateyPackages2nd.schema.psm1
+++ b/source/DSCResources/ChocolateyPackages2nd/ChocolateyPackages2nd.schema.psm1
@@ -11,6 +11,8 @@ configuration ChocolateyPackages2nd {
         [hashtable[]]$Packages
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName Chocolatey
 
@@ -129,4 +131,7 @@ configuration ChocolateyPackages2nd {
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ChocolateyPackages3rd/ChocolateyPackages3rd.schema.psm1
+++ b/source/DSCResources/ChocolateyPackages3rd/ChocolateyPackages3rd.schema.psm1
@@ -11,6 +11,8 @@ configuration ChocolateyPackages3rd {
         [hashtable[]]$Packages
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName Chocolatey
 
@@ -129,4 +131,7 @@ configuration ChocolateyPackages3rd {
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Cluster/Cluster.schema.psm1
+++ b/source/DSCResources/Cluster/Cluster.schema.psm1
@@ -52,6 +52,8 @@ configuration Cluster
         $OrganizationalUnitDn
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xFailoverCluster
     Import-DscResource -ModuleName ActiveDirectoryDsc
@@ -134,4 +136,7 @@ configuration Cluster
             PsDscRunAsCredential               = $DomainAdministratorCredential
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ComputerSettings/ComputerSettings.schema.psm1
+++ b/source/DSCResources/ComputerSettings/ComputerSettings.schema.psm1
@@ -36,6 +36,8 @@ configuration ComputerSettings {
         [string]$RemoteDesktopUserAuthentication
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
 
@@ -75,4 +77,7 @@ configuration ComputerSettings {
         }
         (Get-DscSplattedResource -ResourceName RemoteDesktopAdmin -ExecutionName "RemoteDesktopAdmin$($params.Name)" -Properties $params -NoInvoke).Invoke($params)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ConfigurationBase/ConfigurationBase.schema.psm1
+++ b/source/DSCResources/ConfigurationBase/ConfigurationBase.schema.psm1
@@ -5,6 +5,8 @@ configuration ConfigurationBase {
         [string]$SystemType
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -16,4 +18,7 @@ configuration ConfigurationBase {
         ValueType = 'Dword'
         Ensure    = 'Present'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ConfigurationManagerConfiguration/ConfigurationManagerConfiguration.schema.psm1
+++ b/source/DSCResources/ConfigurationManagerConfiguration/ConfigurationManagerConfiguration.schema.psm1
@@ -89,6 +89,8 @@ Configuration ConfigurationManagerConfiguration
         $SoftwareUpdatePointComponent
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ConfigMgrCBDsc
     Import-DscResource -ModuleName UpdateServicesDsc
@@ -264,4 +266,7 @@ Configuration ConfigurationManagerConfiguration
         }
         (Get-DscSplattedResource -ResourceName CMSoftwareUpdatePointComponent -ExecutionName "UpdatePointConfig$($SiteName -replace '\W')" -Properties $SoftwareUpdatePointComponent -NoInvoke).Invoke($SoftwareUpdatePointComponent)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ConfigurationManagerDeployment/ConfigurationManagerDeployment.schema.psm1
+++ b/source/DSCResources/ConfigurationManagerDeployment/ConfigurationManagerDeployment.schema.psm1
@@ -81,6 +81,8 @@ Configuration ConfigurationManagerDeployment
         $InstallWindowsFeatures = $false
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ConfigMgrCBDsc
     Import-DscResource -ModuleName UpdateServicesDsc
@@ -179,4 +181,7 @@ Configuration ConfigurationManagerDeployment
         Version            = $ConfigMgrVersion
         DependsOn          = '[CMIniFile]CreateSCCMIniFile'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ConfigurationManagerDistributionGroups/ConfigurationManagerDistributionGroups.schema.psm1
+++ b/source/DSCResources/ConfigurationManagerDistributionGroups/ConfigurationManagerDistributionGroups.schema.psm1
@@ -13,6 +13,8 @@ Configuration ConfigurationManagerDistributionGroups
         $DistributionGroups
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ConfigMgrCBDsc
 
@@ -51,4 +53,7 @@ Configuration ConfigurationManagerDistributionGroups
 
         (Get-DscSplattedResource -ResourceName CMDistributionGroup -ExecutionName "configmgr_dg_$($distributionPointGroup.SiteCode)_$($distributionPointGroup.DistributionGroup)" -Properties $distributionPointGroup -NoInvoke).Invoke($distributionPointGroup)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DfsNamespaces/DfsNamespaces.schema.psm1
+++ b/source/DSCResources/DfsNamespaces/DfsNamespaces.schema.psm1
@@ -11,6 +11,8 @@ configuration DfsNamespaces
         $NamespaceConfig
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DfsDsc
 
@@ -42,4 +44,7 @@ configuration DfsNamespaces
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DhcpScopeOptions/DhcpScopeOptions.schema.psm1
+++ b/source/DSCResources/DhcpScopeOptions/DhcpScopeOptions.schema.psm1
@@ -19,6 +19,8 @@ configuration DhcpScopeOptions
     [Value = [string[]]]
 #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xDhcpServer
     Import-DscResource -ModuleName PsDesiredStateConfiguration
 
@@ -32,4 +34,7 @@ configuration DhcpScopeOptions
         $executionName = "$($node.Name)_$($scopeOption.ScopeId)_$($scopeOption.OptionId)"
         (Get-DscSplattedResource -ResourceName DhcpScopeOptionValue  -ExecutionName $executionName -Properties $scopeOption -NoInvoke).Invoke($scopeOption)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DhcpScopes/DhcpScopes.schema.psm1
+++ b/source/DSCResources/DhcpScopes/DhcpScopes.schema.psm1
@@ -11,6 +11,8 @@ configuration DhcpScopes
         $DomainCredential
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xDhcpServer
     Import-DscResource -ModuleName PsDesiredStateConfiguration
 
@@ -34,4 +36,7 @@ configuration DhcpScopes
         $executionName = "$($node.Name)_$($scope.ScopeId)"
         (Get-DscSplattedResource -ResourceName xDhcpServerScope -ExecutionName $executionName -Properties $scope -NoInvoke).Invoke($scope)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DhcpServer/DhcpServer.schema.psm1
+++ b/source/DSCResources/DhcpServer/DhcpServer.schema.psm1
@@ -28,6 +28,8 @@ configuration DhcpServer
         $EnableSecurityGroups
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xDhcpServer
 
@@ -207,4 +209,7 @@ configuration DhcpServer
 
         (Get-DscSplattedResource -ResourceName xDhcpServerAuthorization -ExecutionName 'dhcpSrvAuth' -Properties $Authorization -NoInvoke).Invoke($Authorization)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DhcpServerOptionDefinitions/DhcpServerOptionDefinitions.schema.psm1
+++ b/source/DSCResources/DhcpServerOptionDefinitions/DhcpServerOptionDefinitions.schema.psm1
@@ -18,7 +18,9 @@ configuration DhcpServerOptionDefinitions
     [Ensure = [string]{ Absent | Present }]
     [Multivalued = [bool]]
     [PsDscRunAsCredential = [PSCredential]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName xDhcpServer
     Import-DscResource -ModuleName PsDesiredStateConfiguration
@@ -33,4 +35,7 @@ configuration DhcpServerOptionDefinitions
         $executionName = "$($node.Name)_$($serverOption.OptionId)"
         (Get-DscSplattedResource -ResourceName xDhcpServerOptionDefinition -ExecutionName $executionName -Properties $serverOptionDefinition -NoInvoke).Invoke($serverOptionDefinition)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DhcpServerOptions/DhcpServerOptions.schema.psm1
+++ b/source/DSCResources/DhcpServerOptions/DhcpServerOptions.schema.psm1
@@ -16,7 +16,9 @@ configuration DhcpServerOptions
     [Ensure = [string]{ Absent | Present }]
     [PsDscRunAsCredential = [PSCredential]]
     [Value = [string[]]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName xDhcpServer
     Import-DscResource -ModuleName PsDesiredStateConfiguration
@@ -31,4 +33,7 @@ configuration DhcpServerOptions
         $executionName = "$($node.Name)_$($serverOption.ScopeId)_$($serverOption.OptionId)"
         (Get-DscSplattedResource -ResourceName DhcpServerOptionValue -ExecutionName $executionName -Properties $serverOption -NoInvoke).Invoke($serverOption)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DiskAccessPaths/DiskAccessPaths.schema.psm1
+++ b/source/DSCResources/DiskAccessPaths/DiskAccessPaths.schema.psm1
@@ -6,6 +6,8 @@ configuration DiskAccessPaths
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName StorageDsc
 
     foreach ($item in $Items)
@@ -13,4 +15,7 @@ configuration DiskAccessPaths
         $executionName = $item.AccessPath
         (Get-DscSplattedResource -ResourceName DiskAccessPath -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Disks/Disks.schema.psm1
+++ b/source/DSCResources/Disks/Disks.schema.psm1
@@ -6,6 +6,8 @@ configuration Disks
         $Disks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName StorageDsc
 
@@ -26,4 +28,7 @@ configuration Disks
         $executionName = $disk.DiskId
         (Get-DscSplattedResource -ResourceName Disk -ExecutionName $executionName -Properties $disk -NoInvoke).Invoke($disk)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerARecords/DnsServerARecords.schema.psm1
+++ b/source/DSCResources/DnsServerARecords/DnsServerARecords.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerARecords
         $Records
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -46,4 +48,7 @@ configuration DnsServerARecords
             (Get-DscSplattedResource -ResourceName DnsRecordA -ExecutionName $executionName -Properties $record -NoInvoke).Invoke($record)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerAdZones/DnsServerAdZones.schema.psm1
+++ b/source/DSCResources/DnsServerAdZones/DnsServerAdZones.schema.psm1
@@ -11,6 +11,8 @@ configuration DnsServerAdZones
         $DomainCredential
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -29,4 +31,7 @@ configuration DnsServerAdZones
         $executionName = "$($node.Name)_$($adZone.Name)"
         (Get-DscSplattedResource -ResourceName DnsServerADZone -ExecutionName $executionName -Properties $adZone -NoInvoke).Invoke($adZone)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerCNameRecords/DnsServerCNameRecords.schema.psm1
+++ b/source/DSCResources/DnsServerCNameRecords/DnsServerCNameRecords.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerCNameRecords
         $Records
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -46,4 +48,7 @@ configuration DnsServerCNameRecords
             (Get-DscSplattedResource -ResourceName DnsRecordCname -ExecutionName $executionName -Properties $record -NoInvoke).Invoke($record)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerConditionalForwarders/DnsServerConditionalForwarders.schema.psm1
+++ b/source/DSCResources/DnsServerConditionalForwarders/DnsServerConditionalForwarders.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerConditionalForwarders
         $ConditionalForwarders
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -20,4 +22,7 @@ configuration DnsServerConditionalForwarders
         $executionName = "$($node.Name)_$($conditionalForwarder.Name)"
         (Get-DscSplattedResource -ResourceName DnsServerConditionalForwarder -ExecutionName $executionName -Properties $conditionalForwarder -NoInvoke).Invoke($conditionalForwarder)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerForwarders/DnsServerForwarders.schema.psm1
+++ b/source/DSCResources/DnsServerForwarders/DnsServerForwarders.schema.psm1
@@ -11,6 +11,8 @@ configuration DnsServerForwarders
         $UseRootHint
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -27,4 +29,7 @@ configuration DnsServerForwarders
         IPAddresses      = $IPAddresses
         UseRootHint      = $UseRootHint
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerLegacySettings/DnsServerLegacySettings.schema.psm1
+++ b/source/DSCResources/DnsServerLegacySettings/DnsServerLegacySettings.schema.psm1
@@ -17,6 +17,8 @@ configuration DnsServerLegacySettings {
         $NoForwarderRecursion
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -25,4 +27,7 @@ configuration DnsServerLegacySettings {
 
     $executionName = 'DnsServerSettingLegacy'
     (Get-DscSplattedResource -ResourceName DnsServerSettingLegacy -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerMxRecords/DnsServerMxRecords.schema.psm1
+++ b/source/DSCResources/DnsServerMxRecords/DnsServerMxRecords.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerMxRecords
         $Records
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -46,4 +48,7 @@ configuration DnsServerMxRecords
             (Get-DscSplattedResource -ResourceName DnsRecordMx -ExecutionName $executionName -Properties $record -NoInvoke).Invoke($record)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerPrimaryZones/DnsServerPrimaryZones.schema.psm1
+++ b/source/DSCResources/DnsServerPrimaryZones/DnsServerPrimaryZones.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerPrimaryZones
         $PrimaryZones
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -32,4 +34,7 @@ configuration DnsServerPrimaryZones
 
         (Get-DscSplattedResource -ResourceName DnsServerPrimaryZone -ExecutionName $executionName -Properties $primaryZone -NoInvoke).Invoke($primaryZone)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerQueryResolutionPolicies/DnsServerQueryResolutionPolicies.schema.psm1
+++ b/source/DSCResources/DnsServerQueryResolutionPolicies/DnsServerQueryResolutionPolicies.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerQueryResolutionPolicies
         $Policies
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     foreach ($dnsPol in $Policies)
@@ -66,4 +68,7 @@ configuration DnsServerQueryResolutionPolicies
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerResponseRateLimiting/DnsServerResponseRateLimiting.schema.psm1
+++ b/source/DSCResources/DnsServerResponseRateLimiting/DnsServerResponseRateLimiting.schema.psm1
@@ -19,6 +19,8 @@ configuration DnsServerResponseRateLimiting
         $Exceptions
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     $RrlParams = @{
@@ -117,4 +119,7 @@ configuration DnsServerResponseRateLimiting
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerRootHints/DnsServerRootHints.schema.psm1
+++ b/source/DSCResources/DnsServerRootHints/DnsServerRootHints.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerRootHints
         $RootHints
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -17,4 +19,7 @@ configuration DnsServerRootHints
 
     $executionName = 'RootHints'
     (Get-DscSplattedResource -ResourceName DnsServerRootHint -ExecutionName $executionName -Properties $param -NoInvoke).Invoke($param)
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerSettings/DnsServerSettings.schema.psm1
+++ b/source/DSCResources/DnsServerSettings/DnsServerSettings.schema.psm1
@@ -265,6 +265,8 @@ configuration DnsServerSettings {
         $ZoneWritebackInterval
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -273,4 +275,7 @@ configuration DnsServerSettings {
 
     $executionName = 'DnsServerSetting'
     (Get-DscSplattedResource -ResourceName DnsServerSetting -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DnsServerZonesAging/DnsServerZonesAging.schema.psm1
+++ b/source/DSCResources/DnsServerZonesAging/DnsServerZonesAging.schema.psm1
@@ -7,6 +7,8 @@ configuration DnsServerZonesAging
         $Zones
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DnsServerDsc
 
@@ -24,4 +26,7 @@ configuration DnsServerZonesAging
 
         (Get-DscSplattedResource -ResourceName DnsServerZoneAging -ExecutionName $executionName -Properties $zone -NoInvoke).Invoke($zone)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscDiagnostic/DscDiagnostic.schema.psm1
+++ b/source/DSCResources/DscDiagnostic/DscDiagnostic.schema.psm1
@@ -159,6 +159,8 @@ function Get-DscTraceInformation
 
 Configuration DscDiagnostic {
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName JeaDsc
 
@@ -198,4 +200,7 @@ Configuration DscDiagnostic {
         SessionType     = 'RestrictedRemoteServer'
         ModulesToImport = 'PSDesiredStateConfiguration', 'xDscDiagnostics'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscLcmController/DscLcmController.schema.psm1
+++ b/source/DSCResources/DscLcmController/DscLcmController.schema.psm1
@@ -670,6 +670,8 @@ configuration DscLcmController {
         $WriteTranscripts
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
@@ -814,4 +816,7 @@ configuration DscLcmController {
         RepetitionDuration = 'Indefinitely'
         StartTime          = (Get-Date)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscLcmMaintenanceWindows/DscLcmMaintenanceWindows.schema.psm1
+++ b/source/DSCResources/DscLcmMaintenanceWindows/DscLcmMaintenanceWindows.schema.psm1
@@ -4,6 +4,8 @@ configuration DscLcmMaintenanceWindows {
         [hashtable[]]$MaintenanceWindows
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -99,4 +101,7 @@ configuration DscLcmMaintenanceWindows {
             Force     = $true
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscPullServer/DscPullServer.schema.psm1
+++ b/source/DSCResources/DscPullServer/DscPullServer.schema.psm1
@@ -22,6 +22,8 @@ configuration DscPullServer
         $UseSecurityBestPractices = $false
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DSCResource -ModuleName xPSDesiredStateConfiguration
 
@@ -37,4 +39,7 @@ configuration DscPullServer
         State                    = 'Started'
         UseSecurityBestPractices = $UseSecurityBestPractices
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscPullServerSql/DscPullServerSql.schema.psm1
+++ b/source/DSCResources/DscPullServerSql/DscPullServerSql.schema.psm1
@@ -46,6 +46,8 @@ configuration DscPullServerSql
         $ConfigureFirewall = $false
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DSCResource -ModuleName PSDesiredStateConfiguration
     Import-DSCResource -ModuleName xPSDesiredStateConfiguration
     Import-DSCResource -ModuleName NetworkingDsc
@@ -222,4 +224,7 @@ configuration DscPullServerSql
             DependsOn   = '[xDscWebService]PSDSCPullServer'
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/DscTagging/DscTagging.schema.psm1
+++ b/source/DSCResources/DscTagging/DscTagging.schema.psm1
@@ -25,6 +25,8 @@ configuration DscTagging {
         $Layers
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -134,4 +136,7 @@ configuration DscTagging {
             Force     = $true
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/EnvironmentVariables/EnvironmentVariables.schema.psm1
+++ b/source/DSCResources/EnvironmentVariables/EnvironmentVariables.schema.psm1
@@ -5,18 +5,20 @@ configuration EnvironmentVariables {
         $Variables
     )
 
-<#
-xEnvironment [String] #ResourceName
-{
-    Name = [string]
-    [DependsOn = [string[]]]
-    [Ensure = [string]{ Absent | Present }]
-    [Path = [bool]]
-    [PsDscRunAsCredential = [PSCredential]]
-    [Target = [string[]]{ Machine | Process }]
-    [Value = [string]]
-}
-#>
+    <#
+    xEnvironment [String] #ResourceName
+    {
+        Name = [string]
+        [DependsOn = [string[]]]
+        [Ensure = [string]{ Absent | Present }]
+        [Path = [bool]]
+        [PsDscRunAsCredential = [PSCredential]]
+        [Target = [string[]]{ Machine | Process }]
+        [Value = [string]]
+    }
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
@@ -32,4 +34,7 @@ xEnvironment [String] #ResourceName
 
         (Get-DscSplattedResource -ResourceName xEnvironment -ExecutionName $variable.Name -Properties $variable -NoInvoke).Invoke($variable)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeAutoMountPoints/ExchangeAutoMountPoints.schema.psm1
+++ b/source/DSCResources/ExchangeAutoMountPoints/ExchangeAutoMountPoints.schema.psm1
@@ -52,6 +52,8 @@ configuration ExchangeAutoMountPoints {
         $VolumePrefix = 'EXVOL'
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -Module xExchange
 
@@ -70,4 +72,6 @@ configuration ExchangeAutoMountPoints {
 
     (Get-DscSplattedResource -ResourceName xExchAutoMountPoint -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeConfiguration/ExchangeConfiguration.schema.psm1
+++ b/source/DSCResources/ExchangeConfiguration/ExchangeConfiguration.schema.psm1
@@ -26,6 +26,8 @@ configuration ExchangeConfiguration {
         $AutoDiscoverSiteScope
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     #Import required DSC Modules
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module xExchange
@@ -111,4 +113,6 @@ configuration ExchangeConfiguration {
         InternalUrl          = "https://$InternalNamespace/ews/exchange.asmx"
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeDagProvisioning/ExchangeDagProvisioning.schema.psm1
+++ b/source/DSCResources/ExchangeDagProvisioning/ExchangeDagProvisioning.schema.psm1
@@ -52,6 +52,8 @@ configuration ExchangeDagProvisioning
         $FirstDagMemberName
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     #Import required DSC Modules
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xExchange
@@ -105,4 +107,7 @@ configuration ExchangeDagProvisioning
             DependsOn         = '[xExchWaitForDAG]WaitForDag'
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeMailboxDatabaseCopies/ExchangeMailboxDatabaseCopies.schema.psm1
+++ b/source/DSCResources/ExchangeMailboxDatabaseCopies/ExchangeMailboxDatabaseCopies.schema.psm1
@@ -20,6 +20,8 @@ configuration ExchangeMailboxDatabaseCopies {
     [TruncationLagTime = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -Module xExchange
 
@@ -38,4 +40,7 @@ configuration ExchangeMailboxDatabaseCopies {
         $executionName = $item.Identity
         (Get-DscSplattedResource -ResourceName xExchMailboxDatabaseCopy -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeMailboxDatabases/ExchangeMailboxDatabases.schema.psm1
+++ b/source/DSCResources/ExchangeMailboxDatabases/ExchangeMailboxDatabases.schema.psm1
@@ -44,6 +44,8 @@ configuration ExchangeMailboxDatabases {
     [SkipInitialDatabaseMount = [bool]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -Module xExchange
 
@@ -54,4 +56,7 @@ configuration ExchangeMailboxDatabases {
         $executionName = $item.Name
         (Get-DscSplattedResource -ResourceName xExchMailboxDatabase -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ExchangeProvisioning/ExchangeProvisioning.schema.psm1
+++ b/source/DSCResources/ExchangeProvisioning/ExchangeProvisioning.schema.psm1
@@ -30,6 +30,8 @@ configuration ExchangeProvisioning {
         [string]$IsoDriveLetter
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xExchange
     Import-DscResource -ModuleName ComputerManagementDsc
@@ -84,4 +86,7 @@ configuration ExchangeProvisioning {
         Name      = 'AfterExchangeInstall'
         DependsOn = '[xExchInstall]InstallExchange'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/FileContents/FileContents.schema.psm1
+++ b/source/DSCResources/FileContents/FileContents.schema.psm1
@@ -16,6 +16,8 @@ configuration FileContents
 
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName FileContentDsc
 
@@ -43,4 +45,6 @@ configuration FileContents
         (Get-DscSplattedResource -ResourceName ReplaceText -ExecutionName $executionName -Properties $replaceText -NoInvoke).Invoke($replaceText)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/FilesAndFolders/FilesAndFolders.schema.psm1
+++ b/source/DSCResources/FilesAndFolders/FilesAndFolders.schema.psm1
@@ -5,6 +5,8 @@ configuration FilesAndFolders
         [hashtable[]]$Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName FileSystemDsc
 
@@ -142,4 +144,7 @@ configuration FilesAndFolders
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/FirewallProfiles/FirewallProfiles.schema.psm1
+++ b/source/DSCResources/FirewallProfiles/FirewallProfiles.schema.psm1
@@ -4,6 +4,8 @@ configuration FirewallProfiles {
         [hashtable[]]$Profile
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
@@ -14,4 +16,6 @@ configuration FirewallProfiles {
         (Get-DscSplattedResource -ResourceName FirewallProfile -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/FirewallRules/FirewallRules.schema.psm1
+++ b/source/DSCResources/FirewallRules/FirewallRules.schema.psm1
@@ -4,6 +4,8 @@ configuration FirewallRules {
         [hashtable[]]$Rules
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
@@ -14,4 +16,6 @@ configuration FirewallRules {
         (Get-DscSplattedResource -ResourceName Firewall -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/HostsFileEntries/HostsFileEntries.schema.psm1
+++ b/source/DSCResources/HostsFileEntries/HostsFileEntries.schema.psm1
@@ -7,6 +7,8 @@ configuration HostsFileEntries
         $Entries
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
 
@@ -24,4 +26,7 @@ configuration HostsFileEntries
 
         (Get-DscSplattedResource -ResourceName HostsFile -ExecutionName $executionName -Properties $entry -NoInvoke).Invoke($entry)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/HyperV/HyperV.schema.psm1
+++ b/source/DSCResources/HyperV/HyperV.schema.psm1
@@ -28,6 +28,8 @@ configuration HyperV
         $VMMachines
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName 'xHyper-V'
 
@@ -153,216 +155,216 @@ configuration HyperV
                     # Default is adapter auto configuration with 255.255.0.0 -> 16
                     [int]$netPrefixLength = 16;
 
-                if (-not [string]::IsNullOrWhiteSpace($netAddressSpace))
-                {
-                    $prefixSelect = $netAddressSpace | Select-String '\d+\.\d+\.\d+\.\d+/(\d+)'
-
-                    if ($null -eq $prefixSelect)
+                    if (-not [string]::IsNullOrWhiteSpace($netAddressSpace))
                     {
-                        throw "ERROR: Invalid format of attribute 'AddressSpace'."
+                        $prefixSelect = $netAddressSpace | Select-String '\d+\.\d+\.\d+\.\d+/(\d+)'
+
+                        if ($null -eq $prefixSelect)
+                        {
+                            throw "ERROR: Invalid format of attribute 'AddressSpace'."
+                        }
+
+                        $netPrefixLength = $prefixSelect.Matches.Groups[1].Value
                     }
 
-                    $netPrefixLength = $prefixSelect.Matches.Groups[1].Value
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($netIpAddress) -and -not ($netIpAddress -match '\d+\.\d+\.\d+\.\d+'))
-                {
-                    throw "ERROR: Invalid format of attribute 'IpAddress'."
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($netGateway) -and -not ($netGateway -match '\d+\.\d+\.\d+\.\d+'))
-                {
-                    throw "ERROR: Invalid format of attribute 'Gateway'."
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($netCategory) -and -not ($netCategory -match '^(Public|Private|DomainAuthenticated)$'))
-                {
-                    throw "ERROR: Invalid value of attribute 'NetworkCategory'."
-                }
-
-                Script "vmnet_$executionName"
-                {
-                    TestScript =
+                    if (-not [string]::IsNullOrWhiteSpace($netIpAddress) -and -not ($netIpAddress -match '\d+\.\d+\.\d+\.\d+'))
                     {
-                        [boolean]$result = $true
-                        $netAdapter = Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object { $_.Name -match $using:netName }
-
-                        if ($null -eq $netAdapter)
-                        {
-                            $result = $false
-                            Write-Verbose "NetAdapter containing switch name '$using:netName' not found."
-                        }
-                        elseif (-not [string]::IsNullOrWhiteSpace($using:netGateway))
-                        {
-                            $netIpConfig = Get-NetIPConfiguration -InterfaceIndex $netAdapter.InterfaceIndex
-
-                            if ($null -eq $netIpConfig -or $netIpConfig.IPv4DefaultGateway -ne $using:netGateway)
-                            {
-                                Write-Verbose "NetAdapter '$using:netName' has not the expected default gateway ($using:netGateway)."
-                            }
-                        }
-
-                        if (-not [string]::IsNullOrWhiteSpace($using:netIpAddress))
-                        {
-                            $netIpAddr = Get-NetIPAddress -IPAddress $using:netIpAddress -ErrorAction SilentlyContinue
-
-                            if ($null -eq $netIpAddr -or
-                                $netIpAddr.InterfaceIndex -ne $netAdapter.InterfaceIndex -or
-                                $netIpAddr.PrefixLength -ne $using:netPrefixLength)
-                            {
-                                $result = $false
-                                Write-Verbose "NetAdapter '$using:netName' has not the expected IP configuration ($using:netIpAddress/$using:netPrefixLength)."
-                            }
-                        }
-
-                        # check network category
-                        if (-not [string]::IsNullOrWhiteSpace($using:netCategory))
-                        {
-                            $netProfile = Get-NetConnectionProfile -InterfaceIndex $netAdapter.InterfaceIndex
-
-                            if ($null -eq $netProfile -or $netProfile.NetworkCategory -ne $using:netCategory)
-                            {
-                                $result = $false
-                                Write-Verbose "NetAdapter '$using:netName' has not the expected network category ($using:netCategory)."
-                            }
-                        }
-
-                        # check NAT switch
-                        if ($using:netName -eq $using:natSwitch)
-                        {
-                            $netNat = Get-NetNat -Name $using:netName -ErrorAction SilentlyContinue
-
-                            if (($null -eq $netNat -or
-                                    $netNat.InternalIPInterfaceAddressPrefix -ne $using:netAddressSpace))
-                            {
-                                $result = $false
-                                Write-Verbose "NetNAT '$using:netName' not found or has not the expected configuration."
-                            }
-                        }
-
-                        $result
-                        return $result
+                        throw "ERROR: Invalid format of attribute 'IpAddress'."
                     }
-                    SetScript  =
+
+                    if (-not [string]::IsNullOrWhiteSpace($netGateway) -and -not ($netGateway -match '\d+\.\d+\.\d+\.\d+'))
                     {
-                        $netAdapter = Get-NetAdapter | Where-Object { $_.Name -match $using:netName }
+                        throw "ERROR: Invalid format of attribute 'Gateway'."
+                    }
 
-                        if ($null -eq $netAdapter)
+                    if (-not [string]::IsNullOrWhiteSpace($netCategory) -and -not ($netCategory -match '^(Public|Private|DomainAuthenticated)$'))
+                    {
+                        throw "ERROR: Invalid value of attribute 'NetworkCategory'."
+                    }
+
+                    Script "vmnet_$executionName"
+                    {
+                        TestScript =
                         {
-                            Write-Error "ERROR: NetAdapter containing switch name '$using:netName' not found."
-                            return
-                        }
+                            [boolean]$result = $true
+                            $netAdapter = Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object { $_.Name -match $using:netName }
 
-                        if (-not [string]::IsNullOrWhiteSpace($using:netIpAddress))
-                        {
-                            # remove existing configuration
-                            Remove-NetIPAddress -IPAddress $using:netIpAddress -Confirm:$false -ErrorAction SilentlyContinue
-
-                            # Remove all routes including the default gateway
-                            Remove-NetRoute -InterfaceIndex $netAdapter.InterfaceIndex
-
-                            Write-Verbose "Create IP Address '$using:netIpAddress'..."
-                            $ipAddrParams = @{
-                                IPAddress      = $using:netIpAddress
-                                PrefixLength   = $using:netPrefixLength
-                                InterfaceIndex = $netAdapter.InterfaceIndex
-                            }
-                            if (-not [string]::IsNullOrWhiteSpace($using:netGateway))
+                            if ($null -eq $netAdapter)
                             {
-                                $ipAddrParams.DefaultGateway = $using:netGateway
+                                $result = $false
+                                Write-Verbose "NetAdapter containing switch name '$using:netName' not found."
                             }
-                            New-NetIPAddress @ipAddrParams
-                        }
-
-                        # set network category
-                        if (-not [string]::IsNullOrWhiteSpace($using:netCategory))
-                        {
-                            if ($using:netCategory -eq 'DomainAuthenticated')
+                            elseif (-not [string]::IsNullOrWhiteSpace($using:netGateway))
                             {
-                                Write-Verbose "Set NetworkCategory of NetAdapter '$using:netName' to '$using:netCategory ' is not supported. The computer automatically sets this value when the network is authenticated to a domain controller."
+                                $netIpConfig = Get-NetIPConfiguration -InterfaceIndex $netAdapter.InterfaceIndex
 
-                                # Workaround if the computer is domain joined -> Restart NLA service to restart the network location check
-                                # see https://newsignature.com/articles/network-location-awareness-service-can-ruin-day-fix/
-                                Write-Verbose 'Restarting NLA service to reinitialize the network location check...'
-                                Restart-Service nlasvc -Force
-                                Start-Sleep 5
+                                if ($null -eq $netIpConfig -or $netIpConfig.IPv4DefaultGateway -ne $using:netGateway)
+                                {
+                                    Write-Verbose "NetAdapter '$using:netName' has not the expected default gateway ($using:netGateway)."
+                                }
+                            }
 
+                            if (-not [string]::IsNullOrWhiteSpace($using:netIpAddress))
+                            {
+                                $netIpAddr = Get-NetIPAddress -IPAddress $using:netIpAddress -ErrorAction SilentlyContinue
+
+                                if ($null -eq $netIpAddr -or
+                                    $netIpAddr.InterfaceIndex -ne $netAdapter.InterfaceIndex -or
+                                    $netIpAddr.PrefixLength -ne $using:netPrefixLength)
+                                {
+                                    $result = $false
+                                    Write-Verbose "NetAdapter '$using:netName' has not the expected IP configuration ($using:netIpAddress/$using:netPrefixLength)."
+                                }
+                            }
+
+                            # check network category
+                            if (-not [string]::IsNullOrWhiteSpace($using:netCategory))
+                            {
                                 $netProfile = Get-NetConnectionProfile -InterfaceIndex $netAdapter.InterfaceIndex
 
-                                Write-Verbose "Current NetworkCategory is now: $($netProfile.NetworkCategory)"
-
-                                if ($netProfile.NetworkCategory -ne $using:netCategory)
+                                if ($null -eq $netProfile -or $netProfile.NetworkCategory -ne $using:netCategory)
                                 {
-                                    Write-Error "NetAdapter '$using:netName' is not '$using:netCategory'."
+                                    $result = $false
+                                    Write-Verbose "NetAdapter '$using:netName' has not the expected network category ($using:netCategory)."
                                 }
+                            }
+
+                            # check NAT switch
+                            if ($using:netName -eq $using:natSwitch)
+                            {
+                                $netNat = Get-NetNat -Name $using:netName -ErrorAction SilentlyContinue
+
+                                if (($null -eq $netNat -or
+                                        $netNat.InternalIPInterfaceAddressPrefix -ne $using:netAddressSpace))
+                                {
+                                    $result = $false
+                                    Write-Verbose "NetNAT '$using:netName' not found or has not the expected configuration."
+                                }
+                            }
+
+                            $result
+                            return $result
+                        }
+                        SetScript  =
+                        {
+                            $netAdapter = Get-NetAdapter | Where-Object { $_.Name -match $using:netName }
+
+                            if ($null -eq $netAdapter)
+                            {
+                                Write-Error "ERROR: NetAdapter containing switch name '$using:netName' not found."
+                                return
+                            }
+
+                            if (-not [string]::IsNullOrWhiteSpace($using:netIpAddress))
+                            {
+                                # remove existing configuration
+                                Remove-NetIPAddress -IPAddress $using:netIpAddress -Confirm:$false -ErrorAction SilentlyContinue
+
+                                # Remove all routes including the default gateway
+                                Remove-NetRoute -InterfaceIndex $netAdapter.InterfaceIndex
+
+                                Write-Verbose "Create IP Address '$using:netIpAddress'..."
+                                $ipAddrParams = @{
+                                    IPAddress      = $using:netIpAddress
+                                    PrefixLength   = $using:netPrefixLength
+                                    InterfaceIndex = $netAdapter.InterfaceIndex
+                                }
+                                if (-not [string]::IsNullOrWhiteSpace($using:netGateway))
+                                {
+                                    $ipAddrParams.DefaultGateway = $using:netGateway
+                                }
+                                New-NetIPAddress @ipAddrParams
+                            }
+
+                            # set network category
+                            if (-not [string]::IsNullOrWhiteSpace($using:netCategory))
+                            {
+                                if ($using:netCategory -eq 'DomainAuthenticated')
+                                {
+                                    Write-Verbose "Set NetworkCategory of NetAdapter '$using:netName' to '$using:netCategory ' is not supported. The computer automatically sets this value when the network is authenticated to a domain controller."
+
+                                    # Workaround if the computer is domain joined -> Restart NLA service to restart the network location check
+                                    # see https://newsignature.com/articles/network-location-awareness-service-can-ruin-day-fix/
+                                    Write-Verbose 'Restarting NLA service to reinitialize the network location check...'
+                                    Restart-Service nlasvc -Force
+                                    Start-Sleep 5
+
+                                    $netProfile = Get-NetConnectionProfile -InterfaceIndex $netAdapter.InterfaceIndex
+
+                                    Write-Verbose "Current NetworkCategory is now: $($netProfile.NetworkCategory)"
+
+                                    if ($netProfile.NetworkCategory -ne $using:netCategory)
+                                    {
+                                        Write-Error "NetAdapter '$using:netName' is not '$using:netCategory'."
+                                    }
+                                }
+                                else
+                                {
+                                    Write-Verbose "Set NetworkCategory of NetAdapter '$using:netName' to '$using:netCategory '."
+                                    Set-NetConnectionProfile -InterfaceIndex $netAdapter.InterfaceIndex -NetworkCategory $using:netCategory
+                                }
+                            }
+
+                            if ($using:netName -eq $using:natSwitch)
+                            {
+                                Remove-NetNat $using:netName -Confirm:$false -ErrorAction SilentlyContinue
+
+                                Write-Verbose "Create NetNat '$using:netName'..."
+                                New-NetNat -Name $using:netName -InternalIPInterfaceAddressPrefix $using:netAddressSpace
+                            }
+                        }
+                        GetScript  = { return `
+                            @{
+                                result = 'N/A'
+                            }
+                        }
+                        DependsOn  = "[xVMSwitch]vmswitch_$executionName"
+                    }
+                }
+
+                if ($null -ne $netInterfaceMetric -and $netInterfaceMetric -gt 0)
+                {
+                    Script "vmnetInterfaceMetric_$executionName"
+                    {
+                        TestScript =
+                        {
+                            #the rule 'PSUseDeclaredVarsMoreThanAssignments' is triggered by the result variable even if it is used.
+                            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+                            $netIf = Get-NetIPInterface | Where-Object { $_.InterfaceAlias -match $using:netName }
+                            if ($null -eq $netIf)
+                            {
+                                Write-Verbose "NetAdapter containing switch name '$using:netName' not found."
+                                return $false
+                            }
+
+                            [boolean]$result = $true
+                            $netIf | ForEach-Object {
+                                Write-Verbose "InterfaceMetric $($_.AddressFamily): $($_.InterfaceMetric)"
+                                if ($_.InterfaceMetric -ne $using:netInterfaceMetric)
+                                {
+                                    $result = $false
+                                }
+                            }
+
+                            Write-Verbose "Expected Interface Metric: $using:netInterfaceMetric"
+                            return $result
+                        }
+                        SetScript  =
+                        {
+                            $netIf = Get-NetIPInterface | Where-Object { $_.InterfaceAlias -match $using:netName }
+                            if ($null -eq $netIf)
+                            {
+                                Write-Error "NetAdapter containing switch name '$using:netName' not found."
                             }
                             else
                             {
-                                Write-Verbose "Set NetworkCategory of NetAdapter '$using:netName' to '$using:netCategory '."
-                                Set-NetConnectionProfile -InterfaceIndex $netAdapter.InterfaceIndex -NetworkCategory $using:netCategory
+                                $netIf | ForEach-Object { Write-Verbose "Set $($_.AddressFamily) InterfaceMetric to $($using:netInterfaceMetric)";
+                                    $_ | Set-NetIPInterface -InterfaceMetric $using:netInterfaceMetric }
                             }
                         }
-
-                        if ($using:netName -eq $using:natSwitch)
-                        {
-                            Remove-NetNat $using:netName -Confirm:$false -ErrorAction SilentlyContinue
-
-                            Write-Verbose "Create NetNat '$using:netName'..."
-                            New-NetNat -Name $using:netName -InternalIPInterfaceAddressPrefix $using:netAddressSpace
-                        }
-                    }
-                    GetScript  = { return `
-                        @{
-                            result = 'N/A'
-                        }
-                    }
-                    DependsOn  = "[xVMSwitch]vmswitch_$executionName"
-                }
-            }
-
-            if ($null -ne $netInterfaceMetric -and $netInterfaceMetric -gt 0)
-            {
-                Script "vmnetInterfaceMetric_$executionName"
-                {
-                    TestScript =
-                    {
-                        #the rule 'PSUseDeclaredVarsMoreThanAssignments' is triggered by the result variable even if it is used.
-                        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
-                        $netIf = Get-NetIPInterface | Where-Object { $_.InterfaceAlias -match $using:netName }
-                        if ($null -eq $netIf)
-                        {
-                            Write-Verbose "NetAdapter containing switch name '$using:netName' not found."
-                            return $false
-                        }
-
-                        [boolean]$result = $true
-                        $netIf | ForEach-Object {
-                            Write-Verbose "InterfaceMetric $($_.AddressFamily): $($_.InterfaceMetric)"
-                            if ($_.InterfaceMetric -ne $using:netInterfaceMetric)
-                            {
-                                $result = $false
-                            }
-                        }
-
-                        Write-Verbose "Expected Interface Metric: $using:netInterfaceMetric"
-                        return $result
-                    }
-                    SetScript  =
-                    {
-                        $netIf = Get-NetIPInterface | Where-Object { $_.InterfaceAlias -match $using:netName }
-                        if ($null -eq $netIf)
-                        {
-                            Write-Error "NetAdapter containing switch name '$using:netName' not found."
-                        }
-                        else
-                        {
-                            $netIf | ForEach-Object { Write-Verbose "Set $($_.AddressFamily) InterfaceMetric to $($using:netInterfaceMetric)";
-                                $_ | Set-NetIPInterface -InterfaceMetric $using:netInterfaceMetric }
-                        }
-                    }
-                    GetScript  = { return `
-                        @{
-                            result = 'N/A'
+                        GetScript  = { return `
+                            @{
+                                result = 'N/A'
                             }
                         }
                     }
@@ -461,7 +463,7 @@ configuration HyperV
                     Path             = $strVHDPath
                     MaximumSizeBytes = $iDiskSize
                     Generation       = 'Vhdx'
-                    type             = 'Dynamic'
+                    Type             = 'Dynamic'
                     DependsOn        = "[File]$folderVHD"
                 }
             }
@@ -1099,7 +1101,7 @@ configuration HyperV
                         Path             = $disk.Path
                         MaximumSizeBytes = $iDiskSize
                         Generation       = 'Vhdx'
-                        type             = 'Dynamic'
+                        Type             = 'Dynamic'
                         DependsOn        = "[File]$folderVHD"
                     }
                 }
@@ -1309,4 +1311,7 @@ configuration HyperV
         }
     }
     #endregion
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/IpConfiguration/IpConfiguration.schema.psm1
+++ b/source/DSCResources/IpConfiguration/IpConfiguration.schema.psm1
@@ -7,6 +7,8 @@ configuration IpConfiguration
         $Adapter
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
 
@@ -60,4 +62,7 @@ configuration IpConfiguration
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/JeaEndpoints/JeaEndpoints.schema.psm1
+++ b/source/DSCResources/JeaEndpoints/JeaEndpoints.schema.psm1
@@ -5,6 +5,8 @@ configuration JeaEndpoints {
         $Endpoints
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-Module JeaDsc
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
@@ -26,4 +28,6 @@ configuration JeaEndpoints {
 
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/JeaRoles/JeaRoles.schema.psm1
+++ b/source/DSCResources/JeaRoles/JeaRoles.schema.psm1
@@ -4,6 +4,8 @@ configuration JeaRoles {
         [hashtable[]]$Roles
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-Module JeaDsc
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
@@ -83,4 +85,7 @@ configuration JeaRoles {
         (Get-DscSplattedResource -ResourceName JeaRoleCapabilities -ExecutionName $executionName -Properties $role -NoInvoke).Invoke($role)
 
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/LocalGroups/LocalGroups.schema.psm1
+++ b/source/DSCResources/LocalGroups/LocalGroups.schema.psm1
@@ -5,6 +5,8 @@ configuration LocalGroups {
         $Groups
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
     foreach ($group in $Groups)
@@ -12,4 +14,7 @@ configuration LocalGroups {
         $executionName = $group.GroupName -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xGroup -ExecutionName $executionName -Properties $group -NoInvoke).Invoke($group)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/LocalUsers/LocalUsers.schema.psm1
+++ b/source/DSCResources/LocalUsers/LocalUsers.schema.psm1
@@ -5,6 +5,8 @@ configuration LocalUsers {
         $Users
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -77,4 +79,7 @@ configuration LocalUsers {
 
         AddMemberOf -ExecutionName $executionName -ExecutionType xUser -AccountName $user.UserName -MemberOf $memberOf
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/MmaAgent/MmaAgent.schema.psm1
+++ b/source/DSCResources/MmaAgent/MmaAgent.schema.psm1
@@ -19,6 +19,8 @@ configuration MmaAgent
         $ProxyCredential
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName MmaDsc
 
@@ -26,4 +28,7 @@ configuration MmaAgent
     $PSBoundParameters.Remove('DependsOn')
 
     (Get-DscSplattedResource -ResourceName WorkspaceConfiguration -ExecutionName MmaConfig -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/MountImages/MountImages.schema.psm1
+++ b/source/DSCResources/MountImages/MountImages.schema.psm1
@@ -7,6 +7,8 @@ configuration MountImages
         $Images
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName StorageDsc
 
@@ -42,4 +44,7 @@ configuration MountImages
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Network/Network.schema.psm1
+++ b/source/DSCResources/Network/Network.schema.psm1
@@ -12,6 +12,8 @@ configuration Network {
         $InterfaceAlias = 'Ethernet'
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
@@ -44,4 +46,7 @@ configuration Network {
             Set-NetIPInterface -InterfaceAlias $using:InterfaceAlias -NlMtuBytes $using:MtuSize
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/NetworkIpConfiguration/NetworkIpConfiguration.schema.psm1
+++ b/source/DSCResources/NetworkIpConfiguration/NetworkIpConfiguration.schema.psm1
@@ -20,6 +20,8 @@ configuration NetworkIpConfiguration {
         $Routes
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName NetworkingDsc
@@ -375,4 +377,7 @@ configuration NetworkIpConfiguration {
             (Get-DscSplattedResource -ResourceName Route -ExecutionName $executionName -Properties $netRoute -NoInvoke).Invoke($netRoute)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/OfficeOnlineServerFarmConfig/OfficeOnlineServerFarmConfig.schema.psm1
+++ b/source/DSCResources/OfficeOnlineServerFarmConfig/OfficeOnlineServerFarmConfig.schema.psm1
@@ -204,6 +204,8 @@ configuration OfficeOnlineServerFarmConfig
         $PicturePasteDisabled
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName OfficeOnlineServerDsc
 
@@ -225,4 +227,6 @@ configuration OfficeOnlineServerFarmConfig
     $exeutionName = "$($node.Name)_FarmCreate"
     (Get-DscSplattedResource -ResourceName OfficeOnlineServerFarm -ExecutionName $exeutionName -Properties $param -NoInvoke).Invoke($param)
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/OfficeOnlineServerMachineConfig/OfficeOnlineServerMachineConfig.schema.psm1
+++ b/source/DSCResources/OfficeOnlineServerMachineConfig/OfficeOnlineServerMachineConfig.schema.psm1
@@ -17,6 +17,8 @@ configuration OfficeOnlineServerMachineConfig
         $MachineToJoin
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName OfficeOnlineServerDsc
 
@@ -26,4 +28,6 @@ configuration OfficeOnlineServerMachineConfig
     $exeutionName = "$($node.Name)_FarmJoin"
     (Get-DscSplattedResource -ResourceName OfficeOnlineServerMachine -ExecutionName $exeutionName -Properties $param -NoInvoke).Invoke($param)
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/OfficeOnlineServerSetup/OfficeOnlineServerSetup.schema.psm1
+++ b/source/DSCResources/OfficeOnlineServerSetup/OfficeOnlineServerSetup.schema.psm1
@@ -36,6 +36,8 @@ configuration OfficeOnlineServerSetup
         $Path
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName OfficeOnlineServerDsc
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
@@ -169,4 +171,6 @@ configuration OfficeOnlineServerSetup
     }
     $dependsOnInstallAndLanguagePack += '[OfficeOnlineServerInstall]InstallBinaries'
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/OpticalDiskDrives/OpticalDiskDrives.schema.psm1
+++ b/source/DSCResources/OpticalDiskDrives/OpticalDiskDrives.schema.psm1
@@ -7,6 +7,8 @@ configuration OpticalDiskDrives
         $Drives
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName StorageDsc
 
@@ -27,4 +29,7 @@ configuration OpticalDiskDrives
 
         (Get-DscSplattedResource -ResourceName OpticalDiskDriveLetter -ExecutionName "optDiskDrive$($drive.DiskId)" -Properties $drive -NoInvoke).Invoke($drive)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/PowerPlans/PowerPlans.schema.psm1
+++ b/source/DSCResources/PowerPlans/PowerPlans.schema.psm1
@@ -16,6 +16,8 @@ configuration PowerPlans
         $Settings
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName DSCR_PowerPlan
 
@@ -76,4 +78,7 @@ configuration PowerPlans
 
         (Get-DscSplattedResource -ResourceName cPowerPlanSetting -ExecutionName $executionName -Properties $pwrSetting -NoInvoke).Invoke($pwrSetting)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/PowerShellRepositories/PowerShellRepositories.schema.psm1
+++ b/source/DSCResources/PowerShellRepositories/PowerShellRepositories.schema.psm1
@@ -7,10 +7,15 @@ configuration PowerShellRepositories
         $Repositories
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PowerShellGet -ModuleVersion 2.2.5
 
     foreach ($repo in $Repositories)
     {
         (Get-DscSplattedResource -ResourceName PSRepository -ExecutionName "PSRepo$($repo.Name)" -Properties $repo -NoInvoke).Invoke($repo)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/PowershellExecutionPolicies/PowershellExecutionPolicies.schema.psm1
+++ b/source/DSCResources/PowershellExecutionPolicies/PowershellExecutionPolicies.schema.psm1
@@ -6,6 +6,8 @@ Configuration PowershellExecutionPolicies
         [hashtable[]] $Policies
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName ComputerManagementDsc
 
     foreach ($policy in $Policies)
@@ -15,4 +17,7 @@ Configuration PowershellExecutionPolicies
         $executionName = "PowershellExecutionPolicy_$($policy.ExecutionPolicyScope)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName PowershellExecutionPolicy -ExecutionName $executionName -Properties $policy -NoInvoke).Invoke($policy)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RegistryPolicies/RegistryPolicies.schema.psm1
+++ b/source/DSCResources/RegistryPolicies/RegistryPolicies.schema.psm1
@@ -9,6 +9,8 @@ configuration RegistryPolicies {
         $GpUpdateInterval = 20
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName GPRegistryPolicyDsc
 
@@ -83,4 +85,7 @@ configuration RegistryPolicies {
             DependsOn        = "[RegistryPolicyFile]$executionName"
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RegistryValues/RegistryValues.schema.psm1
+++ b/source/DSCResources/RegistryValues/RegistryValues.schema.psm1
@@ -5,6 +5,8 @@ configuration RegistryValues {
         $Values
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -25,4 +27,7 @@ configuration RegistryValues {
         $executionName = ($value.Key + '__' + $value.ValueName) -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xRegistry -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RemoteDesktopCertificates/RemoteDesktopCertificates.schema.psm1
+++ b/source/DSCResources/RemoteDesktopCertificates/RemoteDesktopCertificates.schema.psm1
@@ -17,6 +17,9 @@ configuration RemoteDesktopCertificates
             [PsDscRunAsCredential = [PSCredential]]
         }
     #>
+
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRemoteDesktopSessionHost
 
     foreach ($certificate in $Certificates)
@@ -25,4 +28,7 @@ configuration RemoteDesktopCertificates
 
         (Get-DscSplattedResource -ResourceName xRDCertificateConfiguration -ExecutionName $executionName -Properties $certificate -NoInvoke).Invoke($certificate)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RemoteDesktopCollections/RemoteDesktopCollections.schema.psm1
+++ b/source/DSCResources/RemoteDesktopCollections/RemoteDesktopCollections.schema.psm1
@@ -41,6 +41,9 @@ configuration RemoteDesktopCollections
             }
         }
     #>
+
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRemoteDesktopSessionHost
 
     foreach ($collection in $Collections)
@@ -70,4 +73,7 @@ configuration RemoteDesktopCollections
             (Get-DscSplattedResource -ResourceName xRDSessionCollectionConfiguration -ExecutionName $executionName -Properties $collectionSettings -NoInvoke).Invoke($collectionSettings)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RemoteDesktopDeployment/RemoteDesktopDeployment.schema.psm1
+++ b/source/DSCResources/RemoteDesktopDeployment/RemoteDesktopDeployment.schema.psm1
@@ -19,6 +19,8 @@ configuration RemoteDesktopDeployment
         $Gateways
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRemoteDesktopSessionHost
 
 
@@ -35,4 +37,7 @@ configuration RemoteDesktopDeployment
 
         (Get-DscSplattedResource -ResourceName xRDSessionDeployment -ExecutionName $executionName -Properties $gateway -NoInvoke).Invoke($gateway)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RemoteDesktopHAMode/RemoteDesktopHAMode.schema.psm1
+++ b/source/DSCResources/RemoteDesktopHAMode/RemoteDesktopHAMode.schema.psm1
@@ -28,6 +28,8 @@ configuration RemoteDesktopHAMode
         $Config
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRemoteDesktopSessionHost
 
     if ($DependsOn -and -not $Config)
@@ -48,4 +50,7 @@ configuration RemoteDesktopHAMode
     }
 
     (Get-DscSplattedResource -ResourceName xRDConnectionBrokerHAMode -ExecutionName RDCBHAMode -Properties $param -NoInvoke).Invoke($param)
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RemoteDesktopLicensing/RemoteDesktopLicensing.schema.psm1
+++ b/source/DSCResources/RemoteDesktopLicensing/RemoteDesktopLicensing.schema.psm1
@@ -15,6 +15,8 @@ configuration RemoteDesktopLicensing
         $LicenseMode
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRemoteDesktopSessionHost
 
 
@@ -32,4 +34,7 @@ configuration RemoteDesktopLicensing
         LicenseServer    = $LicenseServer
         LicenseMode      = $LicenseMode
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/RestartSystem/RestartSystem.schema.psm1
+++ b/source/DSCResources/RestartSystem/RestartSystem.schema.psm1
@@ -33,6 +33,8 @@ configuration RestartSystem
         $SkipCcmClientSDK = $true
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
 
@@ -80,4 +82,7 @@ configuration RestartSystem
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Robocopies/Robocopies.schema.psm1
+++ b/source/DSCResources/Robocopies/Robocopies.schema.psm1
@@ -6,6 +6,8 @@ Configuration Robocopies
         [hashtable[]] $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName xRobocopy
 
     foreach ($item in $Items)
@@ -15,4 +17,7 @@ Configuration Robocopies
         $executionName = "xRobocopy_$($item.Destination)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xRobocopy -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ScheduledTasks/ScheduledTasks.schema.psm1
+++ b/source/DSCResources/ScheduledTasks/ScheduledTasks.schema.psm1
@@ -7,6 +7,8 @@ configuration ScheduledTasks
         $Tasks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
 
@@ -25,4 +27,7 @@ configuration ScheduledTasks
 
         (Get-DscSplattedResource -ResourceName ScheduledTask -ExecutionName $executionName -Properties $task -NoInvoke).Invoke($task)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ScomComponents/ScomComponents.schema.psm1
+++ b/source/DSCResources/ScomComponents/ScomComponents.schema.psm1
@@ -7,6 +7,8 @@ configuration ScomComponents
         $Components
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName cScom
     <#
     [-IsSingleInstance] <string> [-Role] <Role> [-SourcePath] <string> [[-ManagementServer] <string>]
@@ -27,4 +29,7 @@ configuration ScomComponents
 
         (Get-DscSplattedResource -ResourceName ScomComponent -ExecutionName $executionName -Properties $component -NoInvoke).Invoke($component)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ScomManagementPacks/ScomManagementPacks.schema.psm1
+++ b/source/DSCResources/ScomManagementPacks/ScomManagementPacks.schema.psm1
@@ -7,7 +7,10 @@ configuration ScomManagementPacks
         $ManagementPacks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName cScom
+
     <#
     Name
     ManagementPackPath
@@ -26,4 +29,7 @@ configuration ScomManagementPacks
 
         (Get-DscSplattedResource -ResourceName ScomManagementPack -ExecutionName $executionName -Properties $manPack -NoInvoke).Invoke($manPack)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/ScomSettings/ScomSettings.schema.psm1
+++ b/source/DSCResources/ScomSettings/ScomSettings.schema.psm1
@@ -38,6 +38,8 @@ Configuration ScomSettings
         $WebAddressSetting
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName cScom
 
     if (-not [string]::IsNullOrWhiteSpace($ApprovalSetting))
@@ -101,4 +103,7 @@ Configuration ScomSettings
         $WebAddressSetting.IsSingleInstance = 'Yes'
         (Get-DscSplattedResource -ResourceName ScomWebAddressSetting -ExecutionName $executionName -Properties $WebAddressSetting -NoInvoke).Invoke($WebAddressSetting)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Scripts/Scripts.schema.psm1
+++ b/source/DSCResources/Scripts/Scripts.schema.psm1
@@ -5,6 +5,8 @@ configuration Scripts {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -48,4 +50,7 @@ configuration Scripts {
 
         (Get-DscSplattedResource -ResourceName xScript -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SecurityBase/SecurityBase.schema.psm1
+++ b/source/DSCResources/SecurityBase/SecurityBase.schema.psm1
@@ -6,6 +6,8 @@ configuration SecurityBase {
         $Role
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
@@ -61,4 +63,7 @@ configuration SecurityBase {
             Network_security_Do_not_store_LAN_Manager_hash_value_on_next_password_change = 'Enabled'
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SecurityPolicies/SecurityPolicies.schema.psm1
+++ b/source/DSCResources/SecurityPolicies/SecurityPolicies.schema.psm1
@@ -20,6 +20,8 @@ configuration SecurityPolicies
         $SecurityTemplatePath
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SecurityPolicyDsc
 
@@ -68,4 +70,7 @@ configuration SecurityPolicies
         }
         (Get-DscSplattedResource -ResourceName SecurityTemplate -ExecutionName "secTemplate" -Properties $securityTemplate -NoInvoke).Invoke( $securityTemplate )
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointCacheAccounts/SharePointCacheAccounts.schema.psm1
+++ b/source/DSCResources/SharePointCacheAccounts/SharePointCacheAccounts.schema.psm1
@@ -14,7 +14,9 @@ configuration SharePointCacheAccounts
     [InstallAccount = [PSCredential]]
     [PsDscRunAsCredential = [PSCredential]]
     [SetWebAppPolicy = [bool]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -24,4 +26,7 @@ configuration SharePointCacheAccounts
         $executionName = "$($item.SuperUserAlias)-$($item.SuperUserAlias)"
         (Get-DscSplattedResource -ResourceName SPCacheAccounts -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointContentDatabases/SharePointContentDatabases.schema.psm1
+++ b/source/DSCResources/SharePointContentDatabases/SharePointContentDatabases.schema.psm1
@@ -19,7 +19,9 @@ configuration SharePointContentDatabases
     [PsDscRunAsCredential = [PSCredential]]
     [UseSQLAuthentication = [bool]]
     [WarningSiteCount = [UInt16]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -34,4 +36,7 @@ configuration SharePointContentDatabases
         $executionName = $item.Name
         (Get-DscSplattedResource -ResourceName SPContentDatabase -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointManagedAccounts/SharePointManagedAccounts.schema.psm1
+++ b/source/DSCResources/SharePointManagedAccounts/SharePointManagedAccounts.schema.psm1
@@ -16,7 +16,9 @@ configuration SharePointManagedAccounts
     [PreExpireDays = [UInt32]]
     [PsDscRunAsCredential = [PSCredential]]
     [Schedule = [string]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -31,4 +33,7 @@ configuration SharePointManagedAccounts
         $executionName = $item.AccountName
         (Get-DscSplattedResource -ResourceName SPManagedAccount -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointManagedPaths/SharePointManagedPaths.schema.psm1
+++ b/source/DSCResources/SharePointManagedPaths/SharePointManagedPaths.schema.psm1
@@ -15,7 +15,9 @@ configuration SharePointManagedPaths
     [Ensure = [string]{ Absent | Present }]
     [InstallAccount = [PSCredential]]
     [PsDscRunAsCredential = [PSCredential]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -30,4 +32,7 @@ configuration SharePointManagedPaths
         $executionName = Get-Random
         (Get-DscSplattedResource -ResourceName SPManagedPath -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointPrereq/SharePointPrereq.schema.psm1
+++ b/source/DSCResources/SharePointPrereq/SharePointPrereq.schema.psm1
@@ -58,6 +58,8 @@ configuration SharePointPrereq
         $ProductKey
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
     Import-DscResource -ModuleName storageDsc
@@ -96,4 +98,7 @@ configuration SharePointPrereq
         #PsDscRunAsCredential = $SetupAccount
         DependsOn        = '[SPInstallPrereqs]SharePointInstallationPrerequisite'
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointProvisioning/SharePointProvisioning.schema.psm1
+++ b/source/DSCResources/SharePointProvisioning/SharePointProvisioning.schema.psm1
@@ -78,6 +78,8 @@ configuration SharePointProvisioning
         $CentralAdminServerName
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
 
@@ -106,4 +108,6 @@ configuration SharePointProvisioning
 
     (Get-DscSplattedResource -ResourceName SPFarm -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointServiceAppPools/SharePointServiceAppPools.schema.psm1
+++ b/source/DSCResources/SharePointServiceAppPools/SharePointServiceAppPools.schema.psm1
@@ -13,7 +13,9 @@ configuration SharePointServiceAppPools
     [Ensure = [string]{ Absent | Present }]
     [InstallAccount = [PSCredential]]
     [PsDscRunAsCredential = [PSCredential]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -28,4 +30,7 @@ configuration SharePointServiceAppPools
         $executionName = $item.Name -replace ' ', ''
         (Get-DscSplattedResource -ResourceName SPServiceAppPool -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointServiceInstances/SharePointServiceInstances.schema.psm1
+++ b/source/DSCResources/SharePointServiceInstances/SharePointServiceInstances.schema.psm1
@@ -12,7 +12,9 @@ configuration SharePointServiceInstances
     [Ensure = [string]{ Absent | Present }]
     [InstallAccount = [PSCredential]]
     [PsDscRunAsCredential = [PSCredential]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -27,4 +29,7 @@ configuration SharePointServiceInstances
         $executionName = $item.Name -replace ' ', ''
         (Get-DscSplattedResource -ResourceName SPServiceInstance -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointSetup/SharePointSetup.schema.psm1
+++ b/source/DSCResources/SharePointSetup/SharePointSetup.schema.psm1
@@ -146,6 +146,8 @@ configuration SharePointSetup
         $LanguagePacks
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SharePointDSC
 
     # SharePoint Prerequisits Installer
@@ -195,4 +197,7 @@ configuration SharePointSetup
         $i++
         (Get-DscSplattedResource -ResourceName SPInstallLanguagePack -ExecutionName $executionName -Properties $languagePack -NoInvoke).Invoke($languagePack)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointSites/SharePointSites.schema.psm1
+++ b/source/DSCResources/SharePointSites/SharePointSites.schema.psm1
@@ -25,7 +25,9 @@ configuration SharePointSites
     [SecondaryEmail = [string]]
     [SecondaryOwnerAlias = [string]]
     [Template = [string]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -35,4 +37,7 @@ configuration SharePointSites
         $executionName = $item.Name -replace ' ', ''
         (Get-DscSplattedResource -ResourceName SPSite -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SharePointWebApplications/SharePointWebApplications.schema.psm1
+++ b/source/DSCResources/SharePointWebApplications/SharePointWebApplications.schema.psm1
@@ -24,7 +24,9 @@ configuration SharePointWebApplications
     [PsDscRunAsCredential = [PSCredential]]
     [UseClassic = [bool]]
     [UseSQLAuthentication = [bool]]
-#>
+    #>
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SharePointDSC
@@ -39,4 +41,7 @@ configuration SharePointWebApplications
         $executionName = $item.Name -replace ' ', ''
         (Get-DscSplattedResource -ResourceName SPWebApplication -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SmbShares/SmbShares.schema.psm1
+++ b/source/DSCResources/SmbShares/SmbShares.schema.psm1
@@ -14,6 +14,8 @@ configuration SmbShares
         $Shares
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
 
@@ -94,7 +96,7 @@ configuration SmbShares
                 $share.Path = 'Unused'
             }
 
-            # remove duplicates from access rights 
+            # remove duplicates from access rights
             $share.FullAccess   = $() + $share.FullAccess
             $share.ChangeAccess = $() + ($share.ChangeAccess | Where-Object { $share.FullAccess -notcontains $_ })
             $share.ReadAccess   = $() + ($share.ReadAccess   | Where-Object { $share.FullAccess -notcontains $_ -and `
@@ -106,4 +108,7 @@ configuration SmbShares
             (Get-DscSplattedResource -ResourceName SmbShare -ExecutionName "SmbShare_$shareId" -Properties $share -NoInvoke).Invoke($share)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SoftwarePackages/SoftwarePackages.schema.psm1
+++ b/source/DSCResources/SoftwarePackages/SoftwarePackages.schema.psm1
@@ -4,6 +4,8 @@ configuration SoftwarePackages {
         [hashtable[]]$Packages
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -18,4 +20,7 @@ configuration SoftwarePackages {
         $executionName = $p.Name -replace '\(|\)|\.| ', ''
         (Get-DscSplattedResource -ResourceName xPackage -ExecutionName $executionName -Properties $p -NoInvoke).Invoke($p)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAGDatabases/SqlAGDatabases.schema.psm1
+++ b/source/DSCResources/SqlAGDatabases/SqlAGDatabases.schema.psm1
@@ -22,6 +22,8 @@ configuration SqlAGDatabases {
     [ReplaceExisting = [bool]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAGDatabase
 
     foreach ($value in $Values)
@@ -39,4 +41,7 @@ configuration SqlAGDatabases {
         $executionName = "$($value.InstanceName)_$($value.DatabaseName -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlAGDatabase -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAGListeners/SqlAGListeners.schema.psm1
+++ b/source/DSCResources/SqlAGListeners/SqlAGListeners.schema.psm1
@@ -20,6 +20,8 @@ configuration SqlAGListeners {
     [PsDscRunAsCredential = [PSCredential]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAGListener
 
     foreach ($value in $Values)
@@ -37,4 +39,7 @@ configuration SqlAGListeners {
         $executionName = "$($value.InstanceName)_$($value.AvailabilityGroup)_$($value.Name)"
         (Get-DscSplattedResource -ResourceName SqlAGListener -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAGReplicas/SqlAGReplicas.schema.psm1
+++ b/source/DSCResources/SqlAGReplicas/SqlAGReplicas.schema.psm1
@@ -30,6 +30,8 @@ configuration SqlAGReplicas {
     [ReadOnlyRoutingList = [string[]]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAGReplica
 
     foreach ($value in $Values)
@@ -47,4 +49,7 @@ configuration SqlAGReplicas {
         $executionName = "$($value.InstanceName)_$($value.AvailabilityGroupName)_$($value.Name)"
         (Get-DscSplattedResource -ResourceName SqlAGReplica -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAGs/SqlAGs.schema.psm1
+++ b/source/DSCResources/SqlAGs/SqlAGs.schema.psm1
@@ -31,6 +31,8 @@ configuration SqlAGs {
     [PsDscRunAsCredential = [PSCredential]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAG
 
     foreach ($value in $Values)
@@ -48,4 +50,7 @@ configuration SqlAGs {
         $executionName = "$($value.InstanceName)_$($value.Name)"
         (Get-DscSplattedResource -ResourceName SqlAG -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAgentAlerts/SqlAgentAlerts.schema.psm1
+++ b/source/DSCResources/SqlAgentAlerts/SqlAgentAlerts.schema.psm1
@@ -22,6 +22,8 @@ configuration SqlAgentAlerts {
           MessageId: '825'
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAgentAlert
 
     foreach ($alert in $Alerts)
@@ -34,4 +36,7 @@ configuration SqlAgentAlerts {
         $executionName = "SqlAgentAlert_$($alert.Servername)_$($alert.InstanceName)_$($alert.Name -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlAgentAlert -ExecutionName $executionName -Properties $alert -NoInvoke).Invoke($alert)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAgentOperators/SqlAgentOperators.schema.psm1
+++ b/source/DSCResources/SqlAgentOperators/SqlAgentOperators.schema.psm1
@@ -18,6 +18,8 @@ configuration SqlAgentOperators {
           EmailAddress: 'dbateam@company.com' [string]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAgentOperator
 
     foreach ($operator in $AgentOperators)
@@ -30,4 +32,7 @@ configuration SqlAgentOperators {
         $executionName = "SqlAgentOperators_$($operator.ServerName)_$($operator.InstanceName)_$($operator.Name -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlAgentOperator -ExecutionName $executionName -Properties $operator -NoInvoke).Invoke($operator)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAliases/SqlAliases.schema.psm1
+++ b/source/DSCResources/SqlAliases/SqlAliases.schema.psm1
@@ -16,6 +16,8 @@ configuration SqlAliases {
     [UseDynamicTcpPort = [bool]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAlias
 
     foreach ($value in $Values)
@@ -28,4 +30,7 @@ configuration SqlAliases {
         $executionName = $value.Name
         (Get-DscSplattedResource -ResourceName SqlAlias -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlAlwaysOnServices/SqlAlwaysOnServices.schema.psm1
+++ b/source/DSCResources/SqlAlwaysOnServices/SqlAlwaysOnServices.schema.psm1
@@ -17,6 +17,8 @@ configuration SqlAlwaysOnServices {
         $Ensure
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlAlwaysOnService
 
     if (-not $PSBoundParameters.ContainsKey('Ensure'))
@@ -31,4 +33,6 @@ configuration SqlAlwaysOnServices {
     $executionName = "$($ServerName)_$($InstanceName)"
     (Get-DscSplattedResource -ResourceName SqlAlwaysOnService -ExecutionName $executionName -Properties $PSBoundParameters -NoInvoke).Invoke($PSBoundParameters)
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlConfigurations/SqlConfigurations.schema.psm1
+++ b/source/DSCResources/SqlConfigurations/SqlConfigurations.schema.psm1
@@ -20,6 +20,8 @@ configuration SqlConfigurations {
     [ServerName = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlConfiguration
 
     foreach ($option in $Options)
@@ -35,4 +37,7 @@ configuration SqlConfigurations {
         $executionName = "$($option.InstanceName)_$($option.OptionName -replace '[().:\s]', '_')"
         (Get-DscSplattedResource -ResourceName SqlConfiguration -ExecutionName $executionName -Properties $option -NoInvoke).Invoke($option)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlDatabaseMailSetups/SqlDatabaseMailSetups.schema.psm1
+++ b/source/DSCResources/SqlDatabaseMailSetups/SqlDatabaseMailSetups.schema.psm1
@@ -25,6 +25,8 @@ configuration SqlDatabaseMailSetups {
           TcpPort: 25 [String]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlDatabaseMail
 
     foreach ($setup in $MailSetups)
@@ -37,4 +39,7 @@ configuration SqlDatabaseMailSetups {
         $executionName = "SqlMailProfile_$($setup.Servername)_$($setup.InstanceName)_$($setup.AccountName)"
         (Get-DscSplattedResource -ResourceName SqlDatabaseMail -ExecutionName $executionName -Properties $setup -NoInvoke).Invoke($setup)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlDatabases/SqlDatabases.schema.psm1
+++ b/source/DSCResources/SqlDatabases/SqlDatabases.schema.psm1
@@ -22,6 +22,8 @@ configuration SqlDatabases {
     [ServerName = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlDatabase
 
     foreach ($value in $Values)
@@ -39,4 +41,7 @@ configuration SqlDatabases {
         $executionName = "$($value.InstanceName)_$($value.Name -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlDatabase -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlEndpoints/SqlEndpoints.schema.psm1
+++ b/source/DSCResources/SqlEndpoints/SqlEndpoints.schema.psm1
@@ -25,6 +25,8 @@ configuration SqlEndpoints {
     [State = [string]{ Disabled | Started | Stopped }]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlEndpoint
 
     foreach ($value in $Values)
@@ -42,4 +44,7 @@ configuration SqlEndpoints {
         $executionName = "$($value.InstanceName)_$($value.EndpointName -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlEndpoint -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlLogins/SqlLogins.schema.psm1
+++ b/source/DSCResources/SqlLogins/SqlLogins.schema.psm1
@@ -25,6 +25,8 @@ configuration SqlLogins {
     [ServerName = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlLogin
 
     foreach ($value in $Values)
@@ -42,4 +44,7 @@ configuration SqlLogins {
         $executionName = "$($value.InstanceName)_$($value.Name -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlLogin -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlPermissions/SqlPermissions.schema.psm1
+++ b/source/DSCResources/SqlPermissions/SqlPermissions.schema.psm1
@@ -9,6 +9,8 @@ configuration SqlPermissions {
         $Values
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlPermission, ServerPermission
 
     function Get-Permission
@@ -92,4 +94,7 @@ configuration SqlPermissions {
             PermissionToExclude  = $permissionToExclude
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlRoles/SqlRoles.schema.psm1
+++ b/source/DSCResources/SqlRoles/SqlRoles.schema.psm1
@@ -21,6 +21,8 @@ configuration SqlRoles {
     [ServerName = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlRole
 
     foreach ($value in $Values)
@@ -38,4 +40,7 @@ configuration SqlRoles {
         $executionName = "$($value.InstanceName)_$($value.ServerRoleName -replace ' ','')"
         (Get-DscSplattedResource -ResourceName SqlRole -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlScriptQueries/SqlScriptQueries.schema.psm1
+++ b/source/DSCResources/SqlScriptQueries/SqlScriptQueries.schema.psm1
@@ -22,8 +22,12 @@ configuration SqlScriptQueries {
         Variable = [String]
         DisableVariables = [Boolean]
     #>
+
+    $curPSModulePath = $env:PSModulePath
+
     #Hashing Queries for unique Execution/Resourcename
     $HashClass = New-Object System.Security.Cryptography.SHA1Managed
+
     Import-DscResource -ModuleName SqlServerDsc -Name SqlScriptQuery
 
     foreach ($query in $Queries)
@@ -38,4 +42,7 @@ configuration SqlScriptQueries {
         $executionName = "SqlQuery_$($query.ServerName)_$($query.InstanceName)_$($hash)"
         (Get-DscSplattedResource -ResourceName SqlScriptQuery -ExecutionName $executionName -Properties $query -NoInvoke).Invoke($query)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SqlServer/SqlServer.schema.psm1
+++ b/source/DSCResources/SqlServer/SqlServer.schema.psm1
@@ -14,6 +14,8 @@ configuration SqlServer
         $SqlLogins
     )
 
+    $curPSModulePath = $env:PSModulePath
+    
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName SqlServerDsc -Name SqlSetup, SqlLogin
 
@@ -123,4 +125,7 @@ configuration SqlServer
             (Get-DscSplattedResource -ResourceName SqlLogin -ExecutionName $executionName -Properties $login -NoInvoke).Invoke($login)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/SwitchLcmMode/SwitchLcmMode.schema.psm1
+++ b/source/DSCResources/SwitchLcmMode/SwitchLcmMode.schema.psm1
@@ -17,6 +17,8 @@ configuration SwitchLcmMode
         $ConfigurationName
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     $TaskName = 'SwitchLcmMode'
@@ -136,4 +138,7 @@ configuration SwitchLcmMode
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/UpdateServices/UpdateServices.schema.psm1
+++ b/source/DSCResources/UpdateServices/UpdateServices.schema.psm1
@@ -17,6 +17,8 @@ configuration UpdateServices
         $ApprovalRules
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName UpdateServicesDsc
 
@@ -190,4 +192,7 @@ configuration UpdateServices
 
         (Get-DscSplattedResource -ResourceName UpdateServicesCleanup  -ExecutionName wsusCleanup -Properties $CleanUp -NoInvoke).Invoke($CleanUp)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/VSTSAgents/VSTSAgents.schema.psm1
+++ b/source/DSCResources/VSTSAgents/VSTSAgents.schema.psm1
@@ -1,10 +1,12 @@
 Configuration VSTSAgents
 {
-    param 
+    param
     (
         [Parameter(Mandatory = $true)]
         [hashtable[]] $Agents
     )
+
+    $curPSModulePath = $env:PSModulePath
 
     Import-DscResource -ModuleName VSTSAgent
 
@@ -20,4 +22,7 @@ Configuration VSTSAgents
         $executionName = "xVSTSAgent_$($agent.Name)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xVSTSAgent -ExecutionName $executionName -Properties $agent -NoInvoke).Invoke($agent)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/VirtualMemoryFiles/VirtualMemoryFiles.schema.psm1
+++ b/source/DSCResources/VirtualMemoryFiles/VirtualMemoryFiles.schema.psm1
@@ -13,6 +13,8 @@ configuration VirtualMemoryFiles
         $Files
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName ComputerManagementDsc
 
     foreach ($file in $Files)
@@ -20,4 +22,7 @@ configuration VirtualMemoryFiles
         $executionName = $file.Drive
         (Get-DscSplattedResource -ResourceName VirtualMemory -ExecutionName $executionName -Properties $file -NoInvoke).Invoke($file)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WaitForAllNodes/WaitForAllNodes.schema.psm1
+++ b/source/DSCResources/WaitForAllNodes/WaitForAllNodes.schema.psm1
@@ -5,7 +5,10 @@ configuration WaitForAllNodes {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     <#
     NodeName = [string[]]
     ResourceName = [string]
@@ -23,4 +26,6 @@ configuration WaitForAllNodes {
         (Get-DscSplattedResource -ResourceName WaitForAll -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WaitForAnyNode/WaitForAnyNode.schema.psm1
+++ b/source/DSCResources/WaitForAnyNode/WaitForAnyNode.schema.psm1
@@ -5,7 +5,10 @@ configuration WaitForAnyNode {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     <#
     NodeName = [string[]]
     ResourceName = [string]
@@ -23,4 +26,6 @@ configuration WaitForAnyNode {
         (Get-DscSplattedResource -ResourceName WaitForAny -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WaitForSomeNodes/WaitForSomeNodes.schema.psm1
+++ b/source/DSCResources/WaitForSomeNodes/WaitForSomeNodes.schema.psm1
@@ -5,7 +5,10 @@ configuration WaitForSomeNodes {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     <#
     NodeCount = [UInt32]
     NodeName = [string[]]
@@ -24,4 +27,6 @@ configuration WaitForSomeNodes {
         (Get-DscSplattedResource -ResourceName WaitForSome -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/Wds/Wds.schema.psm1
+++ b/source/DSCResources/Wds/Wds.schema.psm1
@@ -60,6 +60,8 @@ configuration Wds
         $DeviceReservations
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName WdsDsc
     Import-DscResource -ModuleName xDhcpServer
@@ -395,4 +397,7 @@ configuration Wds
             (Get-DscSplattedResource -ResourceName WdsDeviceReservation -ExecutionName $executionName -Properties $devRes -NoInvoke).Invoke($devRes)
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebApplicationPools/WebApplicationPools.schema.psm1
+++ b/source/DSCResources/WebApplicationPools/WebApplicationPools.schema.psm1
@@ -5,6 +5,8 @@ configuration WebApplicationPools {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -18,4 +20,7 @@ configuration WebApplicationPools {
         $executionName = $item.Name
         (Get-DscSplattedResource -ResourceName xWebAppPool -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebApplications/WebApplications.schema.psm1
+++ b/source/DSCResources/WebApplications/WebApplications.schema.psm1
@@ -5,6 +5,8 @@ configuration WebApplications {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -23,4 +25,7 @@ configuration WebApplications {
         $executionName = "webapp_$($item.Name -replace '[{}#\-\s]','_')"
         (Get-DscSplattedResource -ResourceName $dscResourceName -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebBrowser/WebBrowser.schema.psm1
+++ b/source/DSCResources/WebBrowser/WebBrowser.schema.psm1
@@ -10,6 +10,8 @@ configuration WebBrowser
         $Edge
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName GPRegistryPolicyDsc
 
@@ -96,4 +98,7 @@ configuration WebBrowser
             DependsOn        = '[RegistryPolicyFile]MicrosoftEdge_RestoreOnStartupURLs'
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebConfigProperties/WebConfigProperties.schema.psm1
+++ b/source/DSCResources/WebConfigProperties/WebConfigProperties.schema.psm1
@@ -15,6 +15,8 @@ configuration WebConfigProperties {
     [Value = [string]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -28,4 +30,7 @@ configuration WebConfigProperties {
         $executionName = "$($item.WebsitePath)_$($item.Filter)_$($item.PropertyName)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xWebConfigProperty -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebConfigPropertyCollections/WebConfigPropertyCollections.schema.psm1
+++ b/source/DSCResources/WebConfigPropertyCollections/WebConfigPropertyCollections.schema.psm1
@@ -19,6 +19,8 @@ configuration WebConfigPropertyCollections {
     [PsDscRunAsCredential = [PSCredential]]
     #>
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -32,4 +34,7 @@ configuration WebConfigPropertyCollections {
         $executionName = "$($item.WebsitePath)_$($item.Filter)_$($item.CollectionName)_$($item.ItemKeyValue)_$($item.ItemPropertyName)" -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName xWebConfigPropertyCollection -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebSites/Websites.schema.psm1
+++ b/source/DSCResources/WebSites/Websites.schema.psm1
@@ -5,6 +5,8 @@ configuration WebSites {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -23,4 +25,7 @@ configuration WebSites {
         $executionName = "website_$($item.Name -replace '[{}#\-\s]','_')"
         (Get-DscSplattedResource -ResourceName $dscResourceName -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WebVirtualDirectories/WebVirtualDirectories.schema.psm1
+++ b/source/DSCResources/WebVirtualDirectories/WebVirtualDirectories.schema.psm1
@@ -5,6 +5,8 @@ configuration WebVirtualDirectories {
         $Items
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWebAdministration
 
@@ -18,4 +20,7 @@ configuration WebVirtualDirectories {
         $executionName = $item.Name
         (Get-DscSplattedResource -ResourceName xWebVirtualDirectory -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WindowsEventForwarding/WindowsEventForwarding.schema.psm1
+++ b/source/DSCResources/WindowsEventForwarding/WindowsEventForwarding.schema.psm1
@@ -23,6 +23,8 @@ configuration WindowsEventForwarding
         $Subscriptions
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xWindowsEventForwarding
 
@@ -30,7 +32,7 @@ configuration WindowsEventForwarding
     {
         Script NetworkServiceInLocalEventLogReadersGroup
         {
-            TestScript = 
+            TestScript =
             {
                 [boolean] $result = $false
 
@@ -40,7 +42,7 @@ configuration WindowsEventForwarding
                 # - Standalone_Server         = 2
                 # - Member_Server_            = 3
                 # - Backup_Domain_Controller  = 4
-                # - Primary_Domain_Controller = 5       
+                # - Primary_Domain_Controller = 5
                 $domainRole = Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty DomainRole
 
                 # SID 'S-1-5-32-573' -> builtin group 'Event Log Readers'
@@ -73,7 +75,7 @@ configuration WindowsEventForwarding
 
                 return $result
             }
-            SetScript = 
+            SetScript =
             {
                 $domainRole = Get-CimInstance -ClassName Win32_ComputerSystem | Select-Object -ExpandProperty DomainRole
 
@@ -92,7 +94,7 @@ configuration WindowsEventForwarding
                     Write-Error "ATTENTION: Adding builtin account 'NT AUTHORITY\NETWORK SERVICE' to domain group 'Event Log Readers' via Powershell is not supported and shall be done manually with RSAT or automatically with a GPO."
                 }
             }
-            GetScript = { return 'NA' }   
+            GetScript = { return 'NA' }
         }
     }
 
@@ -178,4 +180,7 @@ configuration WindowsEventForwarding
             MembersToInclude = "$CollectorName"
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WindowsEventLogs/WindowsEventLogs.schema.psm1
+++ b/source/DSCResources/WindowsEventLogs/WindowsEventLogs.schema.psm1
@@ -5,6 +5,8 @@ configuration WindowsEventLogs {
         $Logs
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName ComputerManagementDsc
 
@@ -21,4 +23,6 @@ configuration WindowsEventLogs {
 
     }
 
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WindowsFeatures/WindowsFeatures.schema.psm1
+++ b/source/DSCResources/WindowsFeatures/WindowsFeatures.schema.psm1
@@ -9,6 +9,8 @@ configuration WindowsFeatures {
         $Features
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     foreach ($n in $Names)
@@ -54,4 +56,7 @@ configuration WindowsFeatures {
     {
         (Get-DscSplattedResource -ResourceName WindowsFeature -ExecutionName $feature.Name -Properties $feature -NoInvoke).Invoke($feature)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
+++ b/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
@@ -13,6 +13,8 @@ configuration WindowsOptionalFeatures {
         $NoWindowsUpdateCheck = $false
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 
     foreach ($n in $Names)
@@ -37,4 +39,7 @@ configuration WindowsOptionalFeatures {
 
         (Get-DscSplattedResource -ResourceName WindowsOptionalFeature -ExecutionName $params.Name -Properties $params -NoInvoke).Invoke($params)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/WindowsServices/WindowsServices.schema.psm1
+++ b/source/DSCResources/WindowsServices/WindowsServices.schema.psm1
@@ -5,6 +5,8 @@ configuration WindowsServices {
         $Services
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
@@ -84,4 +86,7 @@ configuration WindowsServices {
             }
         }
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }

--- a/source/DSCResources/XmlContent/XmlContent.schema.psm1
+++ b/source/DSCResources/XmlContent/XmlContent.schema.psm1
@@ -5,6 +5,8 @@ configuration XmlContent {
         $XmlData
     )
 
+    $curPSModulePath = $env:PSModulePath
+
     Import-DscResource -ModuleName PSDesiredStateConfiguration
     Import-DscResource -ModuleName XmlContentDsc
 
@@ -16,4 +18,7 @@ configuration XmlContent {
         }
         (Get-DscSplattedResource -ResourceName XmlFileContentResource -ExecutionName ($xmlRecord.Path + '_' + $xmlRecord.XPath) -Properties $xmlRecord -NoInvoke).Invoke($xmlRecord)
     }
+
+    # restore PSModulePath to reset changes made during MOF compilation
+    $env:PSModulePath = $curPSModulePath
 }


### PR DESCRIPTION
## Pull Request (PR) description

### Changed
- Save & restore PSModulePath in each DSC resource to avoid unwanted modifications during MOF compilation


## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [X] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/CommonTasks/203)
<!-- Reviewable:end -->
